### PR TITLE
throw if cwebp exits with none zero exit code

### DIFF
--- a/src/Cwebp.php
+++ b/src/Cwebp.php
@@ -8,6 +8,11 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 
+
+class CwebpShellExecutionFailed extends \Exception
+{
+}
+
 class Cwebp implements WebpInterface
 {
     use WebpTrait;
@@ -33,8 +38,23 @@ class Cwebp implements WebpInterface
     public function save(string $outputPath, int $quality = null): bool
     {
         $quality = $quality ?? $this->quality;
+        $cmd = $this->cwebpPath . ' -q ' . $quality . ' ' . $this->image->getPathname() . ' -o ' . $outputPath;
 
-        shell_exec($this->cwebpPath . ' -q ' . $quality . ' ' . $this->image->getPathname() . ' -o ' . $outputPath);
+        exec($cmd, $output, $exitCode);
+
+        if ($exitCode !== 0) {
+            throw new CwebpShellExecutionFailed(
+                'Image conversion to WebP using cwebp failed with error code ' . $exitCode . ".\n"
+                . "This command was used to execute cwebp: \n"
+                . "  " . $cmd . "\n"
+                . (
+                    count($output) ?
+                    "The following output was sent to stdout: \n  " . join("\n  ", $output) :
+                    "No output was sent to stdout"
+                ),
+                $exitCode
+            );
+        }
 
         return File::exists($outputPath);
     }


### PR DESCRIPTION
Before no error was thrown if conversion failed. With this change consumer gets a nice error message:

```
(Buglinjo\\LaravelWebp\\CwebpShellExecutionFailed(code: 127): Image conversion to WebP using cwebp failed with error code 127.
This command was used to execute cwebp: 
  /usr/local/bin/cwebp -q 70 /tmp/phpVUl4Vi -o /tmp/ground-to-webpJeZXRi
No output was sent to stdout at /var/www/vendor/buglinjo/laravel-webp/src/Cwebp.php:46)
```