### PR TITLE
Fix argument type exception in cwebp

### DIFF
--- a/src/Exceptions/CwebpShellExecutionFailed.php
+++ b/src/Exceptions/CwebpShellExecutionFailed.php
@@ -7,25 +7,25 @@ use Throwable;
 
 class CwebpShellExecutionFailed extends Exception
 {
-    public function __construct(string $cmd, $output, $code = 0, Throwable $previous = null)
+    public function __construct(string $cmd, string $output, $code = 0, Throwable $previous = null)
     {
         parent::__construct($this->makeMessage($cmd, $code, $output), $code, $previous);
     }
 
     /**
      * @param string $cmd
-     * @param int $exitCode
-     * @param $output
+     * @param int|null $exitCode
+     * @param string $output
      * @return string
      */
-    protected function makeMessage(string $cmd, int $exitCode, $output): string
+    protected function makeMessage(string $cmd, ?int $exitCode, string $output): string
     {
         return 'Image conversion to WebP using cwebp failed with error code ' . $exitCode . ".\n"
             . "This command was used to execute cwebp: \n"
             . "  " . $cmd . "\n"
             . (
-            count($output)
-                ? "The following output was sent to stdout: \n  " . join("\n  ", $output)
+            trim($output)
+                ? "The following output was sent to stdout: \n$output"
                 : "No output was sent to stdout"
             );
     }


### PR DESCRIPTION
When transitioning to Process I haven't noticed that the `CwebpShellExecutionFailed` expects an array.

This PR fixes that.

There's 1 more issue that should be fixed separately, in my case at least cwebp outputted to stderr, so I got an exception saying "No output was sent to stdout".