### PR TITLE
refactor: when getimagesize returns false then throw exception

### DIFF
--- a/src/PhpGD.php
+++ b/src/PhpGD.php
@@ -24,6 +24,10 @@ class PhpGD implements WebpInterface
         $info = getimagesize($path);
         $isAlpha = false;
 
+        if ($info === false) {
+            throw new ImageMimeNotSupportedException('Image mime type SVG is not supported.');
+        }
+
         switch ($info['mime']) {
             case 'image/jpeg':
                 $image = imagecreatefromjpeg($path);


### PR DESCRIPTION
This solve the Issue: 
- https://github.com/buglinjo/laravel-webp/issues/36

When using svg image the method getimagesize return false. Because svg is an XML file.
Then we should throw new exception