### PR TITLE
Suppress warning messages by `imagecreatefrompng()`

### DIFF
--- a/src/PhpGD.php
+++ b/src/PhpGD.php
@@ -34,7 +34,7 @@ class PhpGD implements WebpInterface
                 break;
             case 'image/png':
                 $isAlpha = true;
-                $image = imagecreatefrompng($path);
+                $image = @imagecreatefrompng($path);
                 break;
             default:
                 throw new ImageMimeNotSupportedException('Image mime type' . $info['mime'] . 'is not supported.');


### PR DESCRIPTION
Since PNG files could be from any source, processing the file using `imagecreatefrompng()` could sometimes throw unhandled warnings thus blocking PHP scripts.

In my case, it was:

`imagecreatefrompng(): gd-png: libpng warning: iCCP: known incorrect sRGB profile`